### PR TITLE
Request to Merge

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -86,7 +86,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
         q100 = new PoolChunkList<T>(this, null, 100, Integer.MAX_VALUE, sizeClass.chunkSize);
         q075 = new PoolChunkList<T>(this, q100, 75, 100, sizeClass.chunkSize);
-        q050 = new PoolChunkList<T>(this, q075, 50, 100, sizeClass.chunkSize);
+        q050 = new PoolChunkList<T>(this, q100, 50, 100, sizeClass.chunkSize);
         q025 = new PoolChunkList<T>(this, q050, 25, 75, sizeClass.chunkSize);
         q000 = new PoolChunkList<T>(this, q025, 1, 50, sizeClass.chunkSize);
         qInit = new PoolChunkList<T>(this, q000, Integer.MIN_VALUE, 25, sizeClass.chunkSize);


### PR DESCRIPTION
### **User description**
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Adjust the link of the `q050` PoolChunkList to reference `q100` instead of `q075` during initialization in the `PoolArena` class.

### Why are these changes being made?

The change corrects the initialization chain for `q050`, ensuring the hierarchy and order of chunk lists adhere to the intended structure for efficient memory allocation and management. Linking `q050` directly to `q100` likely improves performance by optimizing resource management and aligning with the intended allocation logic.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->


___

### **PR Type**
enhancement, bug_fix


___

### **Description**
- Updated the `PoolArena` class to change the `nextList` reference for `q050` from `q075` to `q100`.
- This change reduces the call stack depth of the `PoolChunkList.add(chunk)` method.
- Improves memory allocation efficiency by optimizing the chunk list hierarchy.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PoolArena.java</strong><dd><code>Update PoolChunkList initialization for optimized memory management</code></dd></summary>
<hr>

buffer/src/main/java/io/netty/buffer/PoolArena.java

<li>Changed the <code>nextList</code> reference for <code>q050</code> from <code>q075</code> to <code>q100</code>.<br> <li> Adjusted the initialization chain in the <code>PoolArena</code> constructor.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/4/files#diff-1d8d68ee9b8c0c3368953e38b7c0bf2c5da10b4c4c390512b88bdfbdc5449e7b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information