### PR TITLE
Request to Merge

### DIFF
--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
@@ -122,7 +122,7 @@ public class OcspServerCertificateValidator extends ChannelInboundHandlerAdapter
     protected static DnsNameResolver createDefaultResolver(final IoTransport ioTransport) {
         return new DnsNameResolverBuilder()
                 .eventLoop(ioTransport.eventLoop())
-                .channelFactory(ioTransport.datagramChannel())
+                .datagramChannelFactory(ioTransport.datagramChannel())
                 .socketChannelFactory(ioTransport.socketChannel())
                 .build();
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
@@ -52,14 +52,14 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
             Class<? extends DatagramChannel> channelType,
             DnsServerAddressStreamProvider nameServerProvider) {
         this.dnsResolverBuilder = withSharedCaches(new DnsNameResolverBuilder());
-        dnsResolverBuilder.channelType(channelType).nameServerProvider(nameServerProvider);
+        dnsResolverBuilder.datagramChannelType(channelType).nameServerProvider(nameServerProvider);
     }
 
     public DnsAddressResolverGroup(
             ChannelFactory<? extends DatagramChannel> channelFactory,
             DnsServerAddressStreamProvider nameServerProvider) {
         this.dnsResolverBuilder = withSharedCaches(new DnsNameResolverBuilder());
-        dnsResolverBuilder.channelFactory(channelFactory).nameServerProvider(nameServerProvider);
+        dnsResolverBuilder.datagramChannelFactory(channelFactory).nameServerProvider(nameServerProvider);
     }
 
     private static DnsNameResolverBuilder withSharedCaches(DnsNameResolverBuilder dnsResolverBuilder) {
@@ -83,7 +83,7 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
         // but still keep this to ensure backward compatibility with (potentially) override methods
         EventLoop loop = dnsResolverBuilder.eventLoop;
         return newResolver(loop == null ? (EventLoop) executor : loop,
-                dnsResolverBuilder.channelFactory(),
+                dnsResolverBuilder.datagramChannelFactory(),
                 dnsResolverBuilder.nameServerProvider());
     }
 
@@ -117,7 +117,7 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
         // once again, channelFactory and nameServerProvider are most probably set in builder already,
         // but I do reassign them again to avoid corner cases with override methods
         return builder.eventLoop(eventLoop)
-                .channelFactory(channelFactory)
+                .datagramChannelFactory(channelFactory)
                 .nameServerProvider(nameServerProvider)
                 .build();
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -47,7 +47,7 @@ public final class DnsNameResolverBuilder {
     static final SocketAddress DEFAULT_LOCAL_ADDRESS = new InetSocketAddress(0);
 
     volatile EventLoop eventLoop;
-    private ChannelFactory<? extends DatagramChannel> channelFactory;
+    private ChannelFactory<? extends DatagramChannel> datagramChannelFactory;
     private ChannelFactory<? extends SocketChannel> socketChannelFactory;
     private boolean retryOnTimeout;
 
@@ -105,40 +105,75 @@ public final class DnsNameResolverBuilder {
         return this;
     }
 
-    protected ChannelFactory<? extends DatagramChannel> channelFactory() {
-        return this.channelFactory;
+    ChannelFactory<? extends DatagramChannel> datagramChannelFactory() {
+        return this.datagramChannelFactory;
     }
 
     /**
      * Sets the {@link ChannelFactory} that will create a {@link DatagramChannel}.
+     * <p>
      * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
      * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
      *
-     * @param channelFactory the {@link ChannelFactory}
+     * @param datagramChannelFactory the {@link ChannelFactory}
+     * @return {@code this}
+     * @deprecated use {@link #datagramChannelFactory(ChannelFactory)}
+     */
+    @Deprecated
+    public DnsNameResolverBuilder channelFactory(ChannelFactory<? extends DatagramChannel> datagramChannelFactory) {
+        datagramChannelFactory(datagramChannelFactory);
+        return this;
+    }
+
+    /**
+     * Sets the {@link ChannelFactory} that will create a {@link DatagramChannel}.
+     * <p>
+     * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
+     * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
+     *
+     * @param datagramChannelFactory the {@link ChannelFactory}
      * @return {@code this}
      */
-    public DnsNameResolverBuilder channelFactory(ChannelFactory<? extends DatagramChannel> channelFactory) {
-        this.channelFactory = channelFactory;
+    public DnsNameResolverBuilder datagramChannelFactory(
+            ChannelFactory<? extends DatagramChannel> datagramChannelFactory) {
+        this.datagramChannelFactory = datagramChannelFactory;
         return this;
     }
 
     /**
      * Sets the {@link ChannelFactory} as a {@link ReflectiveChannelFactory} of this type.
      * Use as an alternative to {@link #channelFactory(ChannelFactory)}.
+     * <p>
+     * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
+     * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
+     *
+     * @param channelType the type
+     * @return {@code this}
+     * @deprecated use {@link #datagramChannelType(Class)}
+     */
+    @Deprecated
+    public DnsNameResolverBuilder channelType(Class<? extends DatagramChannel> channelType) {
+        return datagramChannelFactory(new ReflectiveChannelFactory<DatagramChannel>(channelType));
+    }
+
+    /**
+     * Sets the {@link ChannelFactory} as a {@link ReflectiveChannelFactory} of this type.
+     * Use as an alternative to {@link #datagramChannelFactory(ChannelFactory)}.
+     * <p>
      * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
      * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
      *
      * @param channelType the type
      * @return {@code this}
      */
-    public DnsNameResolverBuilder channelType(Class<? extends DatagramChannel> channelType) {
-        return channelFactory(new ReflectiveChannelFactory<DatagramChannel>(channelType));
+    public DnsNameResolverBuilder datagramChannelType(Class<? extends DatagramChannel> channelType) {
+        return datagramChannelFactory(new ReflectiveChannelFactory<DatagramChannel>(channelType));
     }
 
     /**
      * Sets the {@link ChannelFactory} that will create a {@link SocketChannel} for
      * <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> if needed.
-     *
+     * <p>
      * TCP fallback is <strong>not</strong> enabled by default and must be enabled by providing a non-null
      * {@link ChannelFactory} for this method.
      *
@@ -155,7 +190,7 @@ public final class DnsNameResolverBuilder {
      * Sets the {@link ChannelFactory} as a {@link ReflectiveChannelFactory} of this type for
      * <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> if needed.
      * Use as an alternative to {@link #socketChannelFactory(ChannelFactory)}.
-     *
+     * <p>
      * TCP fallback is <strong>not</strong> enabled by default and must be enabled by providing a non-null
      * {@code channelType} for this method.
      *
@@ -170,7 +205,7 @@ public final class DnsNameResolverBuilder {
     /**
      * Sets the {@link ChannelFactory} that will create a {@link SocketChannel} for
      * <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> if needed.
-     *
+     * <p>
      * TCP fallback is <strong>not</strong> enabled by default and must be enabled by providing a non-null
      * {@link ChannelFactory} for this method.
      *
@@ -193,7 +228,7 @@ public final class DnsNameResolverBuilder {
      * Sets the {@link ChannelFactory} as a {@link ReflectiveChannelFactory} of this type for
      * <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> if needed.
      * Use as an alternative to {@link #socketChannelFactory(ChannelFactory)}.
-     *
+     * <p>
      * TCP fallback is <strong>not</strong> enabled by default and must be enabled by providing a non-null
      * {@code channelType} for this method.
      *
@@ -603,7 +638,7 @@ public final class DnsNameResolverBuilder {
 
         return new DnsNameResolver(
                 eventLoop,
-                channelFactory,
+                datagramChannelFactory,
                 socketChannelFactory,
                 retryOnTimeout,
                 resolveCache,
@@ -640,8 +675,8 @@ public final class DnsNameResolverBuilder {
             copiedBuilder.eventLoop(eventLoop);
         }
 
-        if (channelFactory != null) {
-            copiedBuilder.channelFactory(channelFactory);
+        if (datagramChannelFactory != null) {
+            copiedBuilder.datagramChannelFactory(datagramChannelFactory);
         }
 
         copiedBuilder.socketChannelFactory(socketChannelFactory, retryOnTimeout);

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
@@ -44,7 +44,7 @@ public class DnsAddressResolverGroupTest {
         final EventLoop loop = group.next();
         DefaultEventLoopGroup defaultEventLoopGroup = new DefaultEventLoopGroup(1);
         DnsNameResolverBuilder builder = new DnsNameResolverBuilder()
-                .eventLoop(loop).channelType(NioDatagramChannel.class);
+                .eventLoop(loop).datagramChannelType(NioDatagramChannel.class);
         DnsAddressResolverGroup resolverGroup = new DnsAddressResolverGroup(builder);
         try {
             final Promise<?> promise = loop.newPromise();
@@ -77,7 +77,7 @@ public class DnsAddressResolverGroupTest {
         NioEventLoopGroup group = new NioEventLoopGroup(1);
         final EventLoop loop = group.next();
         DnsNameResolverBuilder builder = new DnsNameResolverBuilder()
-                .eventLoop(loop).channelType(NioDatagramChannel.class);
+                .eventLoop(loop).datagramChannelType(NioDatagramChannel.class);
         DnsAddressResolverGroup resolverGroup = new DnsAddressResolverGroup(builder);
         DefaultEventLoopGroup defaultEventLoopGroup = new DefaultEventLoopGroup(2);
         EventLoop eventLoop1 = defaultEventLoopGroup.next();

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
@@ -40,7 +40,7 @@ class DnsNameResolverBuilderTest {
 
     @BeforeEach
     void setUp() {
-        builder = new DnsNameResolverBuilder(GROUP.next()).channelType(NioDatagramChannel.class);
+        builder = new DnsNameResolverBuilder(GROUP.next()).datagramChannelType(NioDatagramChannel.class);
     }
 
     @AfterEach

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
@@ -59,7 +59,7 @@ public class DnsNameResolverClientSubnetTest {
 
     private static DnsNameResolverBuilder newResolver(EventLoopGroup group) {
         return new DnsNameResolverBuilder(group.next())
-                .channelType(NioDatagramChannel.class)
+                .datagramChannelType(NioDatagramChannel.class)
                 .nameServerProvider(
                         new SingletonDnsServerAddressStreamProvider(SocketUtils.socketAddress("8.8.8.8", 53)))
                 .maxQueriesPerResolve(1)

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -396,7 +396,7 @@ public class DnsNameResolverTest {
                                                       TestDnsServer dnsServer) {
         DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
                 .dnsQueryLifecycleObserverFactory(new TestRecursiveCacheDnsQueryLifecycleObserverFactory())
-                .channelType(NioDatagramChannel.class)
+                .datagramChannelType(NioDatagramChannel.class)
                 .maxQueriesPerResolve(1)
                 .decodeIdn(decodeToUnicode)
                 .optResourceEnabled(false)
@@ -1155,7 +1155,7 @@ public class DnsNameResolverTest {
     @Test
     public void testResolveAllHostsFile() {
         final DnsNameResolver resolver = new DnsNameResolverBuilder(group.next())
-                .channelType(NioDatagramChannel.class)
+                .datagramChannelType(NioDatagramChannel.class)
                 .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
                     @Override
                     public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
@@ -1243,7 +1243,7 @@ public class DnsNameResolverTest {
             DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
                     .dnsQueryLifecycleObserverFactory(lifecycleObserverFactory)
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
-                    .channelType(NioDatagramChannel.class)
+                    .datagramChannelType(NioDatagramChannel.class)
                     .queryTimeoutMillis(1000) // We expect timeouts if startDnsServer1 is false
                     .optResourceEnabled(false)
                     .ndots(1);
@@ -1292,7 +1292,7 @@ public class DnsNameResolverTest {
             DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                     .dnsQueryLifecycleObserverFactory(lifecycleObserverFactory)
-                    .channelType(NioDatagramChannel.class)
+                    .datagramChannelType(NioDatagramChannel.class)
                     .optResourceEnabled(false)
                     .ndots(1);
 
@@ -2409,15 +2409,15 @@ public class DnsNameResolverTest {
         ChannelFactory<DatagramChannel> channelFactory =
                 new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class);
         DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
-                .channelFactory(channelFactory);
+                .datagramChannelFactory(channelFactory);
         DnsNameResolverBuilder copiedBuilder = builder.copy();
 
         // change channel factory does not propagate to previously made copy
         ChannelFactory<DatagramChannel> newChannelFactory =
                 new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class);
-        builder.channelFactory(newChannelFactory);
-        assertEquals(channelFactory, copiedBuilder.channelFactory());
-        assertEquals(newChannelFactory, builder.channelFactory());
+        builder.datagramChannelFactory(newChannelFactory);
+        assertEquals(channelFactory, copiedBuilder.datagramChannelFactory());
+        assertEquals(newChannelFactory, builder.datagramChannelFactory());
     }
 
     @Test
@@ -2771,7 +2771,7 @@ public class DnsNameResolverTest {
     public void testChannelFactoryException() {
         final IllegalStateException exception = new IllegalStateException();
         try {
-            newResolver().channelFactory(new ChannelFactory<DatagramChannel>() {
+            newResolver().datagramChannelFactory(new ChannelFactory<DatagramChannel>() {
                 @Override
                 public DatagramChannel newChannel() {
                     throw exception;
@@ -3260,7 +3260,7 @@ public class DnsNameResolverTest {
                     return datagramChannel;
                 }
             };
-            builder.channelFactory(channelFactory);
+            builder.datagramChannelFactory(channelFactory);
             if (tcpFallback) {
                 // If we are configured to use TCP as a fallback also bind a TCP socket
                 serverSocket = startDnsServerAndCreateServerSocket(dnsServer2);
@@ -3423,7 +3423,7 @@ public class DnsNameResolverTest {
                     return datagramChannel;
                 }
             };
-            builder.channelFactory(channelFactory);
+            builder.datagramChannelFactory(channelFactory);
             serverSocket = startDnsServerAndCreateServerSocket(dnsServer2);
             // If we are configured to use TCP as a fallback also bind a TCP socket
             builder.socketChannelType(NioSocketChannel.class, true);
@@ -3507,7 +3507,7 @@ public class DnsNameResolverTest {
                                                              dnsServer2.localAddress());
         final DnsNameResolver resolver = new DnsNameResolverBuilder(group.next())
                 .dnsQueryLifecycleObserverFactory(new TestRecursiveCacheDnsQueryLifecycleObserverFactory())
-                .channelType(NioDatagramChannel.class)
+                .datagramChannelType(NioDatagramChannel.class)
                 .optResourceEnabled(false)
                 .nameServerProvider(nameServerProvider)
                 .build();

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -45,7 +45,7 @@ public class SearchDomainTest {
 
     private DnsNameResolverBuilder newResolver() {
         return new DnsNameResolverBuilder(group.next())
-            .channelType(NioDatagramChannel.class)
+            .datagramChannelType(NioDatagramChannel.class)
             .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer.localAddress()))
             .maxQueriesPerResolve(1)
             .optResourceEnabled(false)

--- a/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
@@ -413,7 +413,7 @@ public class NettyBlockHoundIntegrationTest {
         NioEventLoopGroup group = new NioEventLoopGroup();
         try {
             DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
-                    .channelFactory(NioDatagramChannel::new);
+                    .datagramChannelFactory(NioDatagramChannel::new);
             doTestParseResolverFilesAllowsBlockingCalls(builder::build);
         } finally {
             group.shutdownGracefully();


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Introduced new methods `datagramChannelType` and `datagramChannelFactory` in `DnsNameResolverBuilder` to replace the deprecated `channelType` and `channelFactory` methods.
- Updated various classes and methods to use the new datagram methods for creating `DatagramChannel`.
- Adjusted tests to align with the new method names, ensuring compatibility and correctness.
- Deprecated old methods to guide users towards the new, clearer method names.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>OcspServerCertificateValidator.java</strong><dd><code>Update method to use datagramChannelFactory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java

<li>Replaced <code>channelFactory</code> with <code>datagramChannelFactory</code> in <br><code>createDefaultResolver</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/5/files#diff-315e0cb8649be6d39818c0f20f195662215ffde5f407d6317e491780962abb16">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DnsAddressResolverGroup.java</strong><dd><code>Use datagramChannelType and datagramChannelFactory in resolver group</code></dd></summary>
<hr>

resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java

<li>Replaced <code>channelType</code> and <code>channelFactory</code> with <code>datagramChannelType</code> and <br><code>datagramChannelFactory</code>.<br> <li> Updated method calls to use new datagram methods.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/5/files#diff-8da381fbc75c7f2d5a90e7d69f2f51dd7b53702fdd7e05408479291a1f92442f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DnsNameResolverBuilder.java</strong><dd><code>Introduce datagramChannelType and datagramChannelFactory methods</code></dd></summary>
<hr>

resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java

<li>Deprecated <code>channelType</code> and <code>channelFactory</code> methods.<br> <li> Introduced <code>datagramChannelType</code> and <code>datagramChannelFactory</code> methods.<br> <li> Updated internal references to use new datagram methods.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/5/files#diff-d2dd4e07677259791fff97f0bdbfffb5dc25b3f3f493c779fd47c2de9a08d57f">+49/-14</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>DnsAddressResolverGroupTest.java</strong><dd><code>Update tests to use datagramChannelType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java

<li>Updated tests to use <code>datagramChannelType</code> instead of <code>channelType</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/5/files#diff-96f240fbd2b852b2593f03240751f4da60307f352364cb9a5a2cb725de01a985">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DnsNameResolverBuilderTest.java</strong><dd><code>Modify test setup for datagramChannelType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java

- Updated test setup to use `datagramChannelType`.



</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/5/files#diff-37c10cbb3c2d84d56ac6eaface21cf4c5e29631700017491ee1cb7864353692c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DnsNameResolverClientSubnetTest.java</strong><dd><code>Adjust test configuration for datagramChannelType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java

- Changed test configuration to use `datagramChannelType`.



</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/5/files#diff-f3efe0c6d13c5b4934cce5c246387f977f54761ecad9e23d3499e4ee38aeb212">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DnsNameResolverTest.java</strong><dd><code>Update DnsNameResolverTest to use datagramChannelType</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java

<li>Replaced <code>channelType</code> with <code>datagramChannelType</code> in multiple test <br>methods.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/5/files#diff-fa9c1577020a1310cfbbbf14fbb3473dd12fb5af18841cc929a30e8ee9ea4924">+12/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SearchDomainTest.java</strong><dd><code>Use datagramChannelType in SearchDomainTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java

- Updated test to use `datagramChannelType`.



</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/5/files#diff-6a9caa66d098f7f64bd2f44b7229739cee53b89786d60962ca10029fc7d868bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NettyBlockHoundIntegrationTest.java</strong><dd><code>Update NettyBlockHoundIntegrationTest for datagramChannelFactory</code></dd></summary>
<hr>

transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java

- Modified test to use `datagramChannelFactory`.



</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/5/files#diff-27a399de973ee2c525680c87ae344f68fac760db0d7155764b0454c045e16e04">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information