### PR TITLE
Request to Merge

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -383,6 +383,7 @@ public class DnsNameResolver extends InetNameResolver {
              searchDomains, ndots, decodeIdn, false, 0);
     }
 
+    @SuppressWarnings("deprecation")
     DnsNameResolver(
             EventLoop eventLoop,
             ChannelFactory<? extends DatagramChannel> channelFactory,
@@ -501,11 +502,13 @@ public class DnsNameResolver extends InetNameResolver {
             }
         });
 
+        final ChannelFuture future;
         if (localAddress == null) {
-            localAddress = new InetSocketAddress(0);
+            b.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
+            future = b.register();
+        } else {
+            future = b.bind(localAddress);
         }
-
-        ChannelFuture future = b.bind(localAddress);
         if (future.isDone()) {
             Throwable cause = future.cause();
             if (cause != null) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -29,6 +29,7 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +44,7 @@ import static io.netty.util.internal.ObjectUtil.intValue;
 public final class DnsNameResolverBuilder {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DnsNameResolverBuilder.class);
+    static final SocketAddress DEFAULT_LOCAL_ADDRESS = new InetSocketAddress(0);
 
     volatile EventLoop eventLoop;
     private ChannelFactory<? extends DatagramChannel> channelFactory;
@@ -52,7 +54,7 @@ public final class DnsNameResolverBuilder {
     private DnsCache resolveCache;
     private DnsCnameCache cnameCache;
     private AuthoritativeDnsServerCache authoritativeDnsServerCache;
-    private SocketAddress localAddress;
+    private SocketAddress localAddress = DEFAULT_LOCAL_ADDRESS;
     private Integer minTtl;
     private Integer maxTtl;
     private Integer negativeTtl;


### PR DESCRIPTION
### **User description**



___

### **PR Type**
enhancement


___

### **Description**
- Enhanced `DnsNameResolver` to allow users to skip binding during bootstrap by configuring `null` for `localAddress`.
- Added a default local address in `DnsNameResolverBuilder` to maintain pre-existing behavior.
- Introduced conditional logic to bind or register channels based on the presence of `localAddress`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DnsNameResolver.java</strong><dd><code>Add conditional binding logic to DnsNameResolver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java

<li>Added suppression for deprecation warnings.<br> <li> Introduced conditional binding logic based on <code>localAddress</code>.<br> <li> Used <code>ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION</code> for lazy <br>binding.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/6/files#diff-e7ae8540514a0e3caa415abc27aaee9fe93b7732d318d05a9534686447a162b9">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DnsNameResolverBuilder.java</strong><dd><code>Set default local address in DnsNameResolverBuilder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java

<li>Introduced <code>DEFAULT_LOCAL_ADDRESS</code> for default socket address.<br> <li> Set <code>localAddress</code> to <code>DEFAULT_LOCAL_ADDRESS</code> by default.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/6/files#diff-d2dd4e07677259791fff97f0bdbfffb5dc25b3f3f493c779fd47c2de9a08d57f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor the `DnsNameResolver` and `DnsNameResolverBuilder` to use a default local `InetSocketAddress` and modify the channel binding logic to register the channel without binding if the local address is not specified.

### Why are these changes being made?
This change optimizes the DNS name resolver initialization process by assigning a default `InetSocketAddress` in the builder and adjusting the binding logic to handle cases when no local address is provided, thereby improving flexibility and avoiding potential bind failures. These updates aim to streamline the DNS resolution setup and prevent deprecated warnings in the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->