### PR TITLE
Request to Merge

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -349,13 +349,13 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     }
 
     @Test
-    @Timeout(value = 4000, unit = MILLISECONDS)
+    @Timeout(value = 10, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     public void testThreadCacheDestroyedByThreadCleaner() throws InterruptedException {
         testThreadCacheDestroyed(false);
     }
 
     @Test
-    @Timeout(value = 4000, unit = MILLISECONDS)
+    @Timeout(value = 10, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     public void testThreadCacheDestroyedAfterExitRun() throws InterruptedException {
         testThreadCacheDestroyed(true);
     }


### PR DESCRIPTION
### **User description**



___

### **PR Type**
enhancement, bug_fix, tests


___

### **Description**
- Enhanced the `AdaptivePoolingAllocator` to improve memory management by introducing a `freed` field that prevents chunks from being added to the central queue after finalization.
- Modified the magazine expansion logic to free old magazines, preventing memory waste and handling unused chunks more effectively.
- Enhanced the `allocate` method in the `Magazine` class to return a boolean indicating success or failure, improving error handling.
- Introduced a sentinel `MAGAZINE_FREED` to manage freed magazines and prevent data races.
- Updated test timeout settings in `PooledByteBufAllocatorTest` to use separate thread mode for improved test reliability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AdaptivePoolingAllocator.java</strong><dd><code>Improve memory management and magazine handling in </code><br><code>AdaptivePoolingAllocator</code></dd></summary>
<hr>

buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java

<li>Introduced a <code>freed</code> field to prevent chunks from being added to the <br>central queue after finalization.<br> <li> Modified magazine expansion logic to free old magazines and prevent <br>memory waste.<br> <li> Enhanced <code>allocate</code> method to return a boolean indicating success or <br>failure.<br> <li> Added a sentinel <code>MAGAZINE_FREED</code> to manage freed magazines and prevent <br>data races.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/9/files#diff-57ca23ebd0de1096dc91e73cb1f9c790c66494dd42f3960c71e6521a2b386e2f">+57/-24</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PooledByteBufAllocatorTest.java</strong><dd><code>Update test timeout settings for better reliability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java

- Updated test timeout settings to use separate thread mode.



</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/9/files#diff-5356c1287108c4b93aee8b54109d5ef4d4b9cb2179af1806384e0c520aa9dfe6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove unused imports, add `freed` boolean field for magazine lifecycle management, refactor magazine expansion to copy preferred chunk sizes, enhance memory allocation with race condition handling, and introduce a `MAGAZINE_FREED` marker for proper resource cleanup in `AdaptivePoolingAllocator`.

### Why are these changes being made?

The change addresses resource management improvements by ensuring magazines are freed correctly before being reallocated, preventing memory leaks due to race conditions during memory stripe resizing. Simplifying memory allocation logic by maintaining chunk size preferences during expansion enhances performance and clarity. The unused imports were removed for maintaining clean code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->