### PR TITLE
Request to Merge

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
@@ -161,6 +161,11 @@ final class DnsQueryContextManager {
 
         synchronized int add(DnsQueryContext ctx) {
             int id = idSpace.nextId();
+            if (id == -1) {
+                // -1 means that we couldn't reserve an id to use. In this case return early and not store the
+                // context in the map.
+                return -1;
+            }
             DnsQueryContext oldCtx = map.put(id, ctx);
             assert oldCtx == null;
             return id;


### PR DESCRIPTION
### **User description**



___

### **PR Type**
Bug fix


___

### **Description**
- Added a check to ensure that a `DnsQueryContext` is not stored in the map if a query ID cannot be obtained.
- This change prevents assertion failures by avoiding the storage of contexts without valid IDs.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DnsQueryContextManager.java</strong><dd><code>Prevent storing DnsQueryContext without valid query ID</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java

<li>Added a check to return early if a query ID cannot be reserved.<br> <li> Prevented storing the <code>DnsQueryContext</code> in the map when ID reservation <br>fails.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/11/files#diff-bcc4e1cb8d45c0e29ed7abf42fccc3f7148f39ea82c0ad2d70be1e80feb45046">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a check in the `DnsQueryContextMap` class to handle cases where the `idSpace` fails to reserve an ID by returning early if an ID of -1 is produced.

### Why are these changes being made?

This change is being made to handle the edge case where the `idSpace` fails to provide a resolvable ID, ensuring that no context is stored without a valid ID. This addition improves robustness to prevent potential errors or inconsistencies when adding `DnsQueryContext` entries.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->