### PR TITLE
Request to Merge

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -319,7 +319,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         private static final long serialVersionUID = -8319929980932269688L;
         private static final int MIN_DATUM_TARGET = 1024;
         private static final int MAX_DATUM_TARGET = 65534;
-        private static final int INIT_DATUM_TARGET = 8192;
+        private static final int INIT_DATUM_TARGET = 9;
         private static final int HISTO_MIN_BUCKET_SHIFT = 13; // Smallest bucket is 1 << 13 = 8192 bytes in size.
         private static final int HISTO_MAX_BUCKET_SHIFT = 20; // Biggest bucket is 1 << 20 = 1 MiB bytes in size.
         private static final int HISTO_BUCKET_COUNT = 1 + HISTO_MAX_BUCKET_SHIFT - HISTO_MIN_BUCKET_SHIFT; // 8 buckets.
@@ -357,8 +357,8 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             // so we truncate and roll up the bottom part of the histogram to 8 KiB.
             // The upper size band is 1 MiB, and that gives us exactly 8 size buckets,
             // which is a magical number for JIT optimisations.
-            int normalizedSize = size - 1 >> HISTO_MIN_BUCKET_SHIFT & HISTO_MAX_BUCKET_MASK;
-            return Integer.SIZE - Integer.numberOfLeadingZeros(normalizedSize);
+            int normalizedSize = size - 1 >> HISTO_MIN_BUCKET_SHIFT;
+            return Integer.SIZE - Integer.numberOfLeadingZeros(normalizedSize) & HISTO_MAX_BUCKET_MASK;
         }
 
         private void rotateHistograms() {
@@ -524,7 +524,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             REF_CNT_UP_UPDATER.lazySet(this, 1);
         }
 
-        protected void deallocate() {
+        private void deallocate() {
             Magazine mag = magazine;
             AdaptivePoolingAllocator parent = mag.parent;
             int chunkSize = mag.preferredChunkSize();

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -171,9 +171,10 @@ final class PoolChunk<T> implements PoolChunkMetric {
      */
     private final LongCounter pinnedBytes = PlatformDependent.newLongCounter();
 
-    private final int pageSize;
-    private final int pageShifts;
-    private final int chunkSize;
+    final int pageSize;
+    final int pageShifts;
+    final int chunkSize;
+    final int maxPageIdx;
 
     // Use as cache for ByteBuffer created from the memory. These are just duplicates and so are only a container
     // around the memory itself. These are often needed for operations within the Pooled*ByteBuf and so
@@ -200,6 +201,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         this.pageSize = pageSize;
         this.pageShifts = pageShifts;
         this.chunkSize = chunkSize;
+        this.maxPageIdx = maxPageIdx;
         freeBytes = chunkSize;
 
         runsAvail = newRunsAvailqueueArray(maxPageIdx);
@@ -223,6 +225,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         this.memory = memory;
         pageSize = 0;
         pageShifts = 0;
+        maxPageIdx = 0;
         runsAvailMap = null;
         runsAvail = null;
         runsAvailLock = null;

--- a/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
@@ -28,7 +28,7 @@ import static java.lang.Math.*;
 import java.nio.ByteBuffer;
 
 final class PoolChunkList<T> implements PoolChunkListMetric {
-    private static final Iterator<PoolChunkMetric> EMPTY_METRICS = Collections.<PoolChunkMetric>emptyList().iterator();
+    private static final Iterator<PoolChunkMetric> EMPTY_METRICS = Collections.emptyIterator();
     private final PoolArena<T> arena;
     private final PoolChunkList<T> nextList;
     private final int minUsage;

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -18,9 +18,17 @@ package io.netty.buffer;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.abort;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllocator> extends ByteBufAllocatorTest {
 
@@ -130,6 +138,32 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
 
         buffer.release();
         assertEquals(expectedUsedMemoryAfterRelease(allocator, capacity), metric.usedHeapMemory());
+    }
+
+    @Test
+    public void shouldReuseChunks() throws Exception {
+        int bufSize = 1024 * 1024;
+        ByteBufAllocator allocator = newAllocator(false);
+        allocator.heapBuffer(bufSize, bufSize).release();
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        Class<?> cls = null;
+        try {
+            cls = Class.forName("com.sun.management.ThreadMXBean");
+        } catch (ClassNotFoundException e) {
+            abort("Internal ThreadMXBean not available");
+        }
+        assumeThat(threadMXBean).isInstanceOf(cls);
+        Method getThreadAllocatedBytes = cls.getDeclaredMethod("getThreadAllocatedBytes", long.class);
+        long allocBefore = (long) getThreadAllocatedBytes.invoke(threadMXBean, Thread.currentThread().getId());
+        assumeTrue(allocBefore != -1);
+        for (int i = 0; i < 100; ++i) {
+            allocator.heapBuffer(bufSize, bufSize).release();
+        }
+        long allocAfter = (long) getThreadAllocatedBytes.invoke(threadMXBean, Thread.currentThread().getId());
+        assumeTrue(allocAfter != -1);
+        assertThat(allocAfter - allocBefore)
+                .as("allocated MB: %.3f", (allocAfter - allocBefore) / 1024.0 / 1024.0)
+                .isLessThan(8 * 1024 * 1024);
     }
 
     protected long expectedUsedMemory(T allocator, int capacity) {

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -20,8 +20,8 @@ import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
-import org.junit.jupiter.api.Timeout;
 
 import static io.netty.buffer.PoolChunk.runOffset;
 import static io.netty.buffer.PoolChunk.runPages;
@@ -45,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<PooledByteBufAllocator> {
 
@@ -154,13 +154,13 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
     @Test
     public void testArenaMetricsNoCacheAlign() {
-        Assumptions.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
+        assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
         testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 9, 0, 0, 0, true, 64), 100, 0, 100, 100);
     }
 
     @Test
     public void testArenaMetricsCacheAlign() {
-        Assumptions.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
+        assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
         testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 9, 1000, 1000, 1000, true, 64), 100, 1, 1, 0);
     }
 

--- a/buffer/src/test/java/io/netty/buffer/UnpooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnpooledByteBufAllocatorTest.java
@@ -15,6 +15,8 @@
  */
 package io.netty.buffer;
 
+import org.junit.jupiter.api.Disabled;
+
 public class UnpooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<UnpooledByteBufAllocator> {
 
     @Override
@@ -25,5 +27,10 @@ public class UnpooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<U
     @Override
     protected UnpooledByteBufAllocator newUnpooledAllocator() {
         return new UnpooledByteBufAllocator(false);
+    }
+
+    @Disabled("Not applicable for unpooled allocators")
+    @Override
+    public void shouldReuseChunks() throws Exception {
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -179,10 +179,13 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
     private void testSimpleSend(Bootstrap sb, Bootstrap cb, ByteBuf buf, boolean bindClient,
                                 final byte[] bytes, int count) throws Throwable {
-        for (WrapType type: WrapType.values()) {
-            testSimpleSend0(sb, cb, buf.retain(), bindClient, bytes, count, type);
+        try {
+            for (WrapType type: WrapType.values()) {
+                testSimpleSend0(sb, cb, buf.retain(), bindClient, bytes, count, type);
+            }
+        } finally {
+            assertTrue(buf.release());
         }
-        assertTrue(buf.release());
     }
 
     @Test


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced memory allocation strategy by introducing a caching mechanism for chunks in `PoolArena`.
- Modified `AdaptivePoolingAllocator` parameters and methods to improve allocation efficiency.
- Added tests to verify chunk reuse and updated existing tests with assumptions and timeouts.
- Simplified code and improved consistency across various classes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AdaptivePoolingAllocator.java</strong><dd><code>Modify allocation parameters and method access in </code><br><code>AdaptivePoolingAllocator</code></dd></summary>
<hr>

buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java

<li>Changed <code>INIT_DATUM_TARGET</code> from 8192 to 9.<br> <li> Modified <code>sizeBucket</code> method logic for normalization.<br> <li> Changed access modifier of <code>deallocate</code> method from protected to <br>private.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/15/files#diff-57ca23ebd0de1096dc91e73cb1f9c790c66494dd42f3960c71e6521a2b386e2f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PoolArena.java</strong><dd><code>Implement chunk caching mechanism in PoolArena</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

buffer/src/main/java/io/netty/buffer/PoolArena.java

<li>Introduced <code>AtomicReference</code> for caching last destroyed chunk.<br> <li> Modified <code>newChunk</code> and <code>destroyChunk</code> methods to utilize chunk caching.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/15/files#diff-1d8d68ee9b8c0c3368953e38b7c0bf2c5da10b4c4c390512b88bdfbdc5449e7b">+16/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PoolChunk.java</strong><dd><code>Update PoolChunk fields and constructor for consistency</code>&nbsp; &nbsp; </dd></summary>
<hr>

buffer/src/main/java/io/netty/buffer/PoolChunk.java

<li>Made <code>pageSize</code>, <code>pageShifts</code>, <code>chunkSize</code>, and <code>maxPageIdx</code> fields final.<br> <li> Added <code>maxPageIdx</code> initialization in constructors.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/15/files#diff-6850686cf7ebc7b9ddb873389ded45ebf40e6c1ccf411c44b744e7d3ca2ff774">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PoolChunkList.java</strong><dd><code>Simplify EMPTY_METRICS initialization in PoolChunkList</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

buffer/src/main/java/io/netty/buffer/PoolChunkList.java

<li>Simplified <code>EMPTY_METRICS</code> initialization using <br><code>Collections.emptyIterator()</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/15/files#diff-16d776d1903cc25c580b44aa2742912a41e249a1688cabafa8311476a0dd5c44">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractByteBufAllocatorTest.java</strong><dd><code>Add test for chunk reuse in AbstractByteBufAllocatorTest</code>&nbsp; </dd></summary>
<hr>

buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java

<li>Added a test <code>shouldReuseChunks</code> to verify chunk reuse.<br> <li> Utilized <code>ThreadMXBean</code> for memory allocation tracking.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/15/files#diff-a762fa7e76041abcf63b91454c7056ec80949c395a670c72ed8fb7ebb45166ca">+34/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PooledByteBufAllocatorTest.java</strong><dd><code>Update assumptions and add timeout in PooledByteBufAllocatorTest</code></dd></summary>
<hr>

buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java

<li>Replaced <code>Assumptions.assumeTrue</code> with <code>assumeTrue</code>.<br> <li> Added <code>@Timeout</code> annotation to tests.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/15/files#diff-5356c1287108c4b93aee8b54109d5ef4d4b9cb2179af1806384e0c520aa9dfe6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>UnpooledByteBufAllocatorTest.java</strong><dd><code>Disable chunk reuse test in UnpooledByteBufAllocatorTest</code>&nbsp; </dd></summary>
<hr>

buffer/src/test/java/io/netty/buffer/UnpooledByteBufAllocatorTest.java

- Disabled `shouldReuseChunks` test for unpooled allocators.



</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/15/files#diff-639255ea7047d2b2addcaac4035cd1fe705649e09282ec0de9eeddae400191e1">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DatagramUnicastTest.java</strong><dd><code>Ensure buffer release in DatagramUnicastTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java

<li>Added try-finally block to ensure buffer release in <code>testSimpleSend</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/15/files#diff-143f612c289b3a26e479002249fe9822f5cd4215f27f31e317a475902852c18d">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information