### PR TITLE
Request to Merge

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -258,7 +258,14 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             // Create a one-off chunk for this allocation as the previous allocate call did not work out.
             AbstractByteBuf innerChunk = (AbstractByteBuf) chunkAllocator.allocate(size, maxCapacity);
             Chunk chunk = new Chunk(innerChunk, magazine, false);
-            chunk.readInitInto(into, size, maxCapacity);
+            try {
+                chunk.readInitInto(into, size, maxCapacity);
+            } finally {
+                // As the chunk is an one-off we need to always call release explicitly as readInitInto(...)
+                // will take care of retain once when successful. Once The AdaptiveByteBuf is released it will
+                // completely release the Chunk and so the contained innerChunk.
+                chunk.release();
+            }
         }
     }
 


### PR DESCRIPTION
### **User description**



___

### **PR Type**
Bug fix


___

### **Description**
- Added a `try-finally` block to ensure that one-off allocated chunks are correctly released after use.
- This change prevents memory leaks by ensuring `chunk.release()` is called after `readInitInto`.
- The fix addresses an issue where ByteBufs were not being released properly, leading to resource leaks.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AdaptivePoolingAllocator.java</strong><dd><code>Ensure proper release of one-off allocated chunks to prevent memory </code><br><code>leaks</code></dd></summary>
<hr>

buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java

<li>Added a <code>try-finally</code> block to ensure proper release of one-off <br>allocated chunks.<br> <li> Ensured <code>chunk.release()</code> is called after <code>readInitInto</code> to prevent memory <br>leaks.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/16/files#diff-57ca23ebd0de1096dc91e73cb1f9c790c66494dd42f3960c71e6521a2b386e2f">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a `finally` block to ensure proper release of a one-off chunk in `AdaptivePoolingAllocator.java` after its use, to prevent resource leaks.

### Why are these changes being made?

Previously, there was a risk of resource leaks as the chunk was not always released after allocation. By explicitly calling `release()` in a `finally` block, we ensure the chunk is released even if an exception occurs during `readInitInto()`, improving memory management and stability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->