### PR TITLE
Request to Merge

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -173,8 +173,16 @@ public final class NetUtil {
             // Determine the default somaxconn (server socket backlog) value of the platform.
             // The known defaults:
             // - Windows NT Server 4.0+: 200
-            // - Linux and Mac OS X: 128
-            int somaxconn = PlatformDependent.isWindows() ? 200 : 128;
+            // - Mac OS X: 128
+            // - Linux kernel > 5.4 : 4096
+            int somaxconn;
+            if (PlatformDependent.isWindows()) {
+                somaxconn = 200;
+            } else if (PlatformDependent.isOsx()) {
+                somaxconn = 128;
+            } else {
+                somaxconn = 4096;
+            }
             File file = new File("/proc/sys/net/core/somaxconn");
             BufferedReader in = null;
             try {


### PR DESCRIPTION
### **User description**



___

### **PR Type**
enhancement


___

### **Description**
- Updated the default value of `SO_MAXCONN` for Linux systems to 4096, reflecting changes in Linux kernel version >= 5.4.
- Introduced conditional logic to determine the `SO_MAXCONN` value based on the operating system, maintaining current values for Windows and Mac OS X.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetUtil.java</strong><dd><code>Update default `SO_MAXCONN` value for Linux in `NetUtil`</code>&nbsp; </dd></summary>
<hr>

common/src/main/java/io/netty/util/NetUtil.java

<li>Updated the default value of <code>SO_MAXCONN</code> for Linux to 4096.<br> <li> Added conditional logic to set <code>SO_MAXCONN</code> based on the operating <br>system.<br> <li> Retained existing values for Windows and Mac OS X.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/19/files#diff-23e57529974868b5a8e673f043aa9a9a4b8b16069185dec49508443d25364670">+10/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the default `somaxconn` (server socket backlog) value for Linux to 4096 for kernels greater than 5.4 and refactor the logic for determining platform-specific defaults.

### Why are these changes being made?

The current default of 128 for Linux is outdated for newer kernels which support higher default values, specifically 4096. This change ensures more accurate system tuning by leveraging the latest known defaults and improves the code readability by using separate conditional checks for each platform.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->