### PR TITLE
Request to Merge

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -17,9 +17,12 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -698,6 +701,43 @@ public class HttpRequestDecoderTest {
    @Test
     public void testNulInInitialLine() {
         testInvalidHeaders0("GET / HTTP/1.1\r\u0000\nHost: whatever\r\n\r\n");
+    }
+
+    @Test
+    void reentrantClose() {
+        String requestStr = "GET / HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Content-Length: 0\r\n" +
+                "\r\n" +
+                "GET / HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Content-Length: 0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(), new ChannelInboundHandlerAdapter() {
+            private int i;
+
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                if (i == 0) {
+                    assertInstanceOf(HttpRequest.class, msg);
+                } else if (i == 1) {
+                    assertInstanceOf(LastHttpContent.class, msg);
+                } else if (i == 2) {
+                    assertInstanceOf(HttpRequest.class, msg);
+                } else if (i == 3) {
+                    assertInstanceOf(LastHttpContent.class, msg);
+                }
+                ReferenceCountUtil.release(msg);
+
+                if (++i == 1) {
+                    // first request
+                    ctx.close();
+                }
+            }
+        });
+
+        assertFalse(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        assertFalse(channel.finish());
     }
 
     private static void testInvalidHeaders0(String requestStr) {

--- a/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
@@ -40,9 +40,10 @@ public class FlushConsolidationHandlerTest {
         final AtomicInteger flushCount = new AtomicInteger();
         EmbeddedChannel channel = newChannel(flushCount,  true);
         // Flushes should not go through immediately, as they're scheduled as an async task
-        channel.flush();
+        // To ensure we not run the async task directly we will call trigger the flush() via the pipeline.
+        channel.pipeline().flush();
         assertEquals(0, flushCount.get());
-        channel.flush();
+        channel.pipeline().flush();
         assertEquals(0, flushCount.get());
         // Trigger the execution of the async task
         channel.runPendingTasks();
@@ -56,7 +57,8 @@ public class FlushConsolidationHandlerTest {
         EmbeddedChannel channel = newChannel(flushCount, true);
         // After a given threshold, the async task should be bypassed and a flush should be triggered immediately
         for (int i = 0; i < EXPLICIT_FLUSH_AFTER_FLUSHES; i++) {
-            channel.flush();
+            // To ensure we not run the async task directly we will call trigger the flush() via the pipeline.
+            channel.pipeline().flush();
         }
         assertEquals(1, flushCount.get());
         assertFalse(channel.finish());


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Added a new test `reentrantClose` in `HttpRequestDecoderTest` to verify behavior when a channel is closed reentrantly.
- Updated `FlushConsolidationHandlerTest` to use `channel.pipeline().flush()` ensuring flush is triggered via the pipeline.
- Enhanced `EmbeddedChannel` by introducing `executingStackCnt` to track execution stack count and conditionally run pending tasks.
- Wrapped channel operations in `EmbeddedChannel` to manage execution stack count and ensure pending tasks are run appropriately.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HttpRequestDecoderTest.java</strong><dd><code>Add test for reentrant channel close in HttpRequestDecoder</code></dd></summary>
<hr>

codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java

<li>Added a new test <code>reentrantClose</code> to verify behavior when a channel is <br>closed reentrantly.<br> <li> Utilized <code>EmbeddedChannel</code> and <code>ChannelInboundHandlerAdapter</code> for the <br>test.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/21/files#diff-51b8f45110c90865019c7e0326b46928153f107363c122d3bba5d340e2a18453">+40/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>FlushConsolidationHandlerTest.java</strong><dd><code>Update flush tests to use pipeline flush method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java

<li>Modified test to use <code>channel.pipeline().flush()</code> instead of <br><code>channel.flush()</code>.<br> <li> Ensured flush is triggered via the pipeline to avoid direct async task <br>execution.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/21/files#diff-df68287b2a2cb055642006b1ba27c31e1f36446ac0fa4fca7566867f86537a4e">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EmbeddedChannel.java</strong><dd><code>Enhance EmbeddedChannel with execution stack tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java

<li>Introduced <code>executingStackCnt</code> to track execution stack count.<br> <li> Added <code>maybeRunPendingTasks</code> to conditionally run pending tasks.<br> <li> Wrapped various channel operations to manage <code>executingStackCnt</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/21/files#diff-38b41bdeedd74c3c7175774533cb1d219270aaeb31c8594c13dd1106963d37a4">+321/-54</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information