### PR TITLE
Request to Merge

### DIFF
--- a/transport-native-unix-common/src/test/java/io/netty/channel/unix/NativeInetAddressTest.java
+++ b/transport-native-unix-common/src/test/java/io/netty/channel/unix/NativeInetAddressTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.unix;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NativeInetAddressTest {
+
+    @Test
+    public void testAddressNotIncludeScopeId() {
+        int port = 80;
+        ByteBuffer buffer = ByteBuffer.wrap(new byte[24]);
+        buffer.put(new byte[] {'0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '1'});
+        buffer.putInt(0);
+        buffer.putInt(port);
+        InetSocketAddress address = NativeInetAddress.address(buffer.array(), 0, buffer.capacity());
+        assertEquals(port, address.getPort());
+        assertInstanceOf(Inet6Address.class, address.getAddress());
+        assertFalse(address.getAddress().isLinkLocalAddress());
+        assertEquals("3030:3030:3030:3030:3030:3030:3030:3031", address.getAddress().getHostName());
+    }
+
+    @Test
+    public void testLinkOnlyAddressIncludeScopeId() {
+        int port = 80;
+        ByteBuffer buffer = ByteBuffer.wrap(new byte[24]);
+        buffer.put(new byte[] {
+                (byte) 0xfe, (byte) (byte) 0x80, '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '1'});
+        buffer.putInt(0);
+        buffer.putInt(port);
+        InetSocketAddress address = NativeInetAddress.address(buffer.array(), 0, buffer.capacity());
+        assertEquals(port, address.getPort());
+        assertInstanceOf(Inet6Address.class, address.getAddress());
+        assertTrue(address.getAddress().isLinkLocalAddress());
+        assertEquals("fe80:3030:3030:3030:3030:3030:3030:3031%0", address.getAddress().getHostName());
+    }
+}


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed the logic in `NativeInetAddress` to include `scopeId` only for link-local addresses or if explicitly set by the OS.
- Added unit tests to verify the correct behavior of `scopeId` inclusion in `NativeInetAddress`.
- Ensured that the `scopeId` is not included for non-link-local addresses unless explicitly set.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NativeInetAddress.java</strong><dd><code>Fix scopeId inclusion logic for InetAddress construction</code>&nbsp; </dd></summary>
<hr>

transport-native-unix-common/src/main/java/io/netty/channel/unix/NativeInetAddress.java

<li>Modified logic to include <code>scopeId</code> only for link-local addresses or if <br>explicitly set.<br> <li> Added condition to check if the address is link-local before including <br><code>scopeId</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/22/files#diff-90c3b9ee2d2785404bd9f431ac0ac345153bf531e3eb4cebf48280f9651cb561">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NativeInetAddressTest.java</strong><dd><code>Add unit tests for scopeId handling in NativeInetAddress</code>&nbsp; </dd></summary>
<hr>

transport-native-unix-common/src/test/java/io/netty/channel/unix/NativeInetAddressTest.java

<li>Added unit tests for <code>NativeInetAddress</code> to verify <code>scopeId</code> inclusion <br>logic.<br> <li> Tested both scenarios: with and without <code>scopeId</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/22/files#diff-11000993c667b3ad44f790daf767a045457529f7a310d938ef6062a59c3a43be">+56/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information