### PR TITLE
Request to Merge

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -513,11 +513,17 @@ public final class DnsNameResolverBuilder {
         return this;
     }
 
-    private DnsCache newCache() {
+   DnsCache getOrNewCache() {
+        if (this.resolveCache != null) {
+            return this.resolveCache;
+        }
         return new DefaultDnsCache(intValue(minTtl, 0), intValue(maxTtl, Integer.MAX_VALUE), intValue(negativeTtl, 0));
     }
 
-    private AuthoritativeDnsServerCache newAuthoritativeDnsServerCache() {
+   AuthoritativeDnsServerCache getOrNewAuthoritativeDnsServerCache() {
+        if (this.authoritativeDnsServerCache != null) {
+            return this.authoritativeDnsServerCache;
+        }
         return new DefaultAuthoritativeDnsServerCache(
                 intValue(minTtl, 0), intValue(maxTtl, Integer.MAX_VALUE),
                 // Let us use the sane ordering as DnsNameResolver will be used when returning
@@ -530,7 +536,10 @@ public final class DnsNameResolverBuilder {
         return new ThreadLocalNameServerAddressStream(dnsServerAddressStreamProvider);
     }
 
-    private DnsCnameCache newCnameCache() {
+   DnsCnameCache getOrNewCnameCache() {
+        if (this.cnameCache != null) {
+            return this.cnameCache;
+        }
         return new DefaultDnsCnameCache(
                 intValue(minTtl, 0), intValue(maxTtl, Integer.MAX_VALUE));
     }
@@ -583,10 +592,9 @@ public final class DnsNameResolverBuilder {
             logger.debug("authoritativeDnsServerCache and TTLs are mutually exclusive. TTLs are ignored.");
         }
 
-        DnsCache resolveCache = this.resolveCache != null ? this.resolveCache : newCache();
-        DnsCnameCache cnameCache = this.cnameCache != null ? this.cnameCache : newCnameCache();
-        AuthoritativeDnsServerCache authoritativeDnsServerCache = this.authoritativeDnsServerCache != null ?
-                this.authoritativeDnsServerCache : newAuthoritativeDnsServerCache();
+        DnsCache resolveCache = getOrNewCache();
+        DnsCnameCache cnameCache = getOrNewCnameCache();
+        AuthoritativeDnsServerCache authoritativeDnsServerCache = getOrNewAuthoritativeDnsServerCache();
 
         DnsServerAddressStream queryDnsServerAddressStream = this.queryDnsServerAddressStream != null ?
                 this.queryDnsServerAddressStream : newQueryServerAddressStream(dnsServerAddressStreamProvider);

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
@@ -20,16 +20,21 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.resolver.AddressResolver;
+import io.netty.resolver.InetSocketAddressResolver;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.UnsupportedAddressTypeException;
+import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DnsAddressResolverGroupTest {
@@ -65,5 +70,51 @@ public class DnsAddressResolverGroupTest {
             group.shutdownGracefully();
             defaultEventLoopGroup.shutdownGracefully();
         }
+    }
+
+    @Test
+    public void testSharedDNSCacheAcrossEventLoops() throws InterruptedException, ExecutionException {
+        NioEventLoopGroup group = new NioEventLoopGroup(1);
+        final EventLoop loop = group.next();
+        DnsNameResolverBuilder builder = new DnsNameResolverBuilder()
+                .eventLoop(loop).channelType(NioDatagramChannel.class);
+        DnsAddressResolverGroup resolverGroup = new DnsAddressResolverGroup(builder);
+        DefaultEventLoopGroup defaultEventLoopGroup = new DefaultEventLoopGroup(2);
+        EventLoop eventLoop1 = defaultEventLoopGroup.next();
+        EventLoop eventLoop2 = defaultEventLoopGroup.next();
+        try {
+            final Promise<InetSocketAddress> promise1 = loop.newPromise();
+            InetSocketAddressResolver resolver1 = (InetSocketAddressResolver) resolverGroup.getResolver(eventLoop1);
+            InetAddress address1 =
+                    resolve(resolver1, InetSocketAddress.createUnresolved("netty.io", 80), promise1);
+            final Promise<InetSocketAddress> promise2 = loop.newPromise();
+            InetSocketAddressResolver resolver2 = (InetSocketAddressResolver) resolverGroup.getResolver(eventLoop2);
+            InetAddress address2 =
+                    resolve(resolver2, InetSocketAddress.createUnresolved("netty.io", 80), promise2);
+            assertSame(address1, address2);
+        } finally {
+            resolverGroup.close();
+            group.shutdownGracefully();
+            defaultEventLoopGroup.shutdownGracefully();
+        }
+    }
+
+    private InetAddress resolve(InetSocketAddressResolver resolver, SocketAddress socketAddress,
+                                final Promise<InetSocketAddress> promise)
+            throws InterruptedException, ExecutionException {
+        resolver.resolve(socketAddress)
+                .addListener(new FutureListener<InetSocketAddress>() {
+                    @Override
+                    public void operationComplete(Future<InetSocketAddress> future) {
+                        try {
+                            promise.setSuccess(future.get());
+                        } catch (Throwable cause) {
+                            promise.setFailure(cause);
+                        }
+                    }
+                }).await();
+        promise.sync();
+        InetSocketAddress inetSocketAddress = promise.get();
+        return inetSocketAddress.getAddress();
     }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed potential DNS cache invalidation by sharing DNS caches among EventLoops in `DnsAddressResolverGroup`.
- Introduced `withSharedCaches` method to ensure DNS caches are shared.
- Added methods in `DnsNameResolverBuilder` to get or create DNS caches.
- Implemented a new unit test to verify shared DNS cache functionality across different EventLoops.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DnsAddressResolverGroup.java</strong><dd><code>Share DNS caches among EventLoops in DnsAddressResolverGroup</code></dd></summary>
<hr>

resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java

<li>Introduced <code>withSharedCaches</code> method to share DNS caches among <br>EventLoops.<br> <li> Modified constructors to use shared caches.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/24/files#diff-8da381fbc75c7f2d5a90e7d69f2f51dd7b53702fdd7e05408479291a1f92442f">+11/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DnsNameResolverBuilder.java</strong><dd><code>Add methods to get or create DNS caches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java

<li>Added methods to get or create DNS caches if not present.<br> <li> Replaced direct cache creation with new methods.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/24/files#diff-d2dd4e07677259791fff97f0bdbfffb5dc25b3f3f493c779fd47c2de9a08d57f">+15/-7</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DnsAddressResolverGroupTest.java</strong><dd><code>Add test for shared DNS cache across EventLoops</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java

<li>Added a new test <code>testSharedDNSCacheAcrossEventLoops</code>.<br> <li> Verified shared DNS cache functionality across EventLoops.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/netty/pull/24/files#diff-96f240fbd2b852b2593f03240751f4da60307f352364cb9a5a2cb725de01a985">+51/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information